### PR TITLE
NOvA MC indexing compatability

### DIFF
--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -17,12 +17,14 @@ endif
 noinst_PROGRAMS = rechunk \
                   add_key \
                   sort_file_list \
-                  check_seq_incr
+                  check_seq_incr \
+                  add_spill_index
 
 rechunk_SOURCES = rechunk.c
 add_key_SOURCES = add_key.cpp
 sort_file_list_SOURCES = sort_file_list.cpp
 check_seq_incr_SOURCES = check_seq_incr.cpp
+add_spill_index_SOURCES = add_spill_index.cpp
 
 EXTRA_DIST = README.md \
              batch.sh
@@ -36,5 +38,6 @@ dist-hook:
 	$(SED_I) -e "s|_PH5CONCAT_RELEASE_DATE_|@PH5CONCAT_RELEASE_DATE@|g" $(distdir)/sort_file_list.cpp
 	$(SED_I) -e "s|_PH5CONCAT_VERSION_|@PH5CONCAT_VERSION@|g" $(distdir)/check_seq_incr.cpp
 	$(SED_I) -e "s|_PH5CONCAT_RELEASE_DATE_|@PH5CONCAT_RELEASE_DATE@|g" $(distdir)/check_seq_incr.cpp
+	$(SED_I) -e "s|_PH5CONCAT_RELEASE_DATE_|@PH5CONCAT_RELEASE_DATE@|g" $(distdir)/add_spill_index.cpp
 
 .PHONY:

--- a/utils/README.md
+++ b/utils/README.md
@@ -184,24 +184,25 @@ file can be used as an input to the parallel dataset concatenation program
 order of run and subrun IDs.
 
 Command usage:
-  ```
-  % ./sort_file_list -h
-  Usage: ./sort_file_list [-h|-v|-d|-o outfile] infile
-    [-h]          print this command usage message
-    [-v]          verbose mode (default: off)
-    [-d]          debug mode (default: off)
-    [-o outfile]  output file name (default: 'out_list.txt')
-    infile        input file name contains a list of HDF5 file names (required)
-
-    This utility program re-order the files in infile into a sorted list based
-    on the increasing order of 'run' and 'subrun' IDs. Requirements for the
-    input HDF5 files:
-      1. must contain datasets '/spill/run' and '/spill/subrun'
-      2. may contain multiple groups at root level
-      3. each group may contain multiple 2D datasets
-      4. 1st dimension of all datasets in the same group share the same size
-      5. each group must contain datasets 'run' and 'subrun'
-      6. data type of datasets 'run' and 'subrun' must be H5T_STD_U32LE
+ ```
+     [-h]          print this command usage message
+     [-v]          verbose mode (default: off)
+     [-d]          debug mode (default: off)
+     [-a]          full path to dataset used as additional index in multi-index sorting
+     multiple values allowed
+     [-o outfile]  output file name (default: 'out_list.txt')
+     infile        input file name contains a list of HDF5 file names (required)
+    
+     This utility program re-order the files in infile into a sorted list based
+     on the increasing order of 'run' and 'subrun' IDs. Additional IDs can be used to sort with
+     argument -a. Eg, -a /rec.hdr/cycle.
+     Requirements for the input HDF5 files:
+     1. must contain datasets '/spill/run' and '/spill/subrun'
+     2. may contain multiple groups at root level
+     3. each group may contain multiple 2D datasets
+     4. 1st dimension of all datasets in the same group share the same size
+     5. each group must contain datasets 'run' and 'subrun'
+     6. data type of datasets 'run' and 'subrun' must be H5T_STD_U32LE
     *ph5concat version 1.1.0 of March 1, 2020.
   ```
 Example run and output:

--- a/utils/README.md
+++ b/utils/README.md
@@ -185,28 +185,28 @@ The output file can be used as an input to the parallel dataset concatenation pr
 order of run and subrun IDs.
 
 Command usage:
-     ```
-     % ./sort_file_list -h
-     [-h]          print this command usage message
-     [-v]          verbose mode (default: off)
-     [-d]          debug mode (default: off)
-     [-a]          full path to dataset used as additional index in multi-index sorting
-     multiple values allowed
-     [-o outfile]  output file name (default: 'out_list.txt')
-     infile        input file name contains a list of HDF5 file names (required)
-    
-     This utility program re-order the files in infile into a sorted list based
-     on the increasing order of 'run' and 'subrun' IDs. Additional IDs can be used to sort with
-     argument -a. Eg, -a /rec.hdr/cycle.
-     Requirements for the input HDF5 files:
-     1. must contain datasets '/spill/run' and '/spill/subrun'
-     2. may contain multiple groups at root level
-     3. each group may contain multiple 2D datasets
-     4. 1st dimension of all datasets in the same group share the same size
-     5. each group must contain datasets 'run' and 'subrun'
-     6. data type of datasets 'run' and 'subrun' must be H5T_STD_U32LE
-    *ph5concat version 1.1.0 of March 1, 2020.
-    ```
+   ```
+   % ./sort_file_list -h
+   [-h]          print this command usage message
+   [-v]          verbose mode (default: off)
+   [-d]          debug mode (default: off)
+   [-a]          full path to dataset used as additional index in multi-index sorting
+   multiple values allowed
+   [-o outfile]  output file name (default: 'out_list.txt')
+   infile        input file name contains a list of HDF5 file names (required)
+  
+   This utility program re-order the files in infile into a sorted list based
+   on the increasing order of 'run' and 'subrun' IDs. Additional IDs can be used to sort with
+   argument -a. Eg, -a /rec.hdr/cycle.
+   Requirements for the input HDF5 files:
+   1. must contain datasets '/spill/run' and '/spill/subrun'
+   2. may contain multiple groups at root level
+   3. each group may contain multiple 2D datasets
+   4. 1st dimension of all datasets in the same group share the same size
+   5. each group must contain datasets 'run' and 'subrun'
+   6. data type of datasets 'run' and 'subrun' must be H5T_STD_U32LE
+  *ph5concat version 1.1.0 of March 1, 2020.
+  ```
 Example run and output:
   ```
   % cat sample_in_list.txt 

--- a/utils/README.md
+++ b/utils/README.md
@@ -177,14 +177,16 @@ Example run and output:
 
 **sort_file_list** is a utility program to be run in sequential. Given  a list
 of NOvA file names, it sorts the file names based on the values of two
-datasets: 'run' and 'subrun'. The sorted file names are stored in a text file.
-The sorting order first follows the run IDs and then subrun IDs. The output
-file can be used as an input to the parallel dataset concatenation program
+datasets: 'run' and 'subrun' by default. The sorted file names are stored in a text file.
+The sorting order first follows the run IDs and then subrun IDs. Additional datasets 
+can be included in the sorting with `-a`.
+The output file can be used as an input to the parallel dataset concatenation program
 `ph5_concat`, so that the concatenated data is organized in  an increasing
 order of run and subrun IDs.
 
 Command usage:
- ```
+     ```
+     % ./sort_file_list -h
      [-h]          print this command usage message
      [-v]          verbose mode (default: off)
      [-d]          debug mode (default: off)
@@ -204,7 +206,7 @@ Command usage:
      5. each group must contain datasets 'run' and 'subrun'
      6. data type of datasets 'run' and 'subrun' must be H5T_STD_U32LE
     *ph5concat version 1.1.0 of March 1, 2020.
-  ```
+    ```
 Example run and output:
   ```
   % cat sample_in_list.txt 

--- a/utils/add_key.cpp
+++ b/utils/add_key.cpp
@@ -597,7 +597,7 @@ int main(int argc, char **argv)
 
 	/* open index level dataset */
 	level_id = H5Dopen(file_id, index_levels[ilvl].c_str(), H5P_DEFAULT);
-	if (level_id < 0) RETURN_ERROR("H5Dopen", index_levels[ilvl]);
+	if (level_id < 0) RETURN_ERROR("H5Dopen", index_levels[ilvl].c_str());
 
 	/* read the entire dataset */
 	err = H5Dread(level_id, H5T_NATIVE_UINT, H5S_ALL, H5S_ALL, H5P_DEFAULT,

--- a/utils/add_spill_index.cpp
+++ b/utils/add_spill_index.cpp
@@ -1,0 +1,394 @@
+/*
+ * Copyright (C) 2019, Northwestern University and Fermi National Accelerator
+ * Laboratory
+ * See COPYRIGHT notice in top-level directory.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h> /* strcmp(), strdup() */
+#include <unistd.h> /* getopt() */
+#include <assert.h> /* assert() */
+
+#include <string>
+#include <vector>
+
+#include <hdf5.h>
+
+using namespace std;
+
+static int verbose;
+
+#define RETURN_ERROR(func_name, obj_name) {				\
+	printf("Error in %s line %d: calling %s for object %s\n",__FILE__,__LINE__,func_name,obj_name); \
+	return -1;							\
+    }
+
+#define HANDLE_ERROR(msg) {				\
+    printf("Error at line %d: %s\n",__LINE__, msg);	\
+    err_exit = -1;					\
+    goto fn_exit;					\
+}
+
+#define CALLBACK_ERROR(func_name, dset_name) {			\
+    printf("Error in %s line %d: calling %s for group %s dataset %s\n",__FILE__,__LINE__,func_name, grp_name, dset_name); \
+    return -1;								\
+}
+
+/* string-based basename */
+string basename(string full_path)
+{
+    auto pos = full_path.find_last_of("/\\");
+    if(pos != string::npos)
+      return full_path.substr(pos+1);
+    else
+      return full_path;
+}
+
+/*----< incr_raw_data_chunk_cache() >----------------------------------------*/
+static
+int incr_raw_data_chunk_cache(hid_t fapl_id)
+{
+    int err_exit=0;
+    herr_t err;
+
+    /* set the raw data chunk cache to improve (de)compression time */
+    int mdc_nelmts;      /* Dummy parameter in API, no longer used by HDF5 */
+    size_t rdcc_nslots;  /* Number of slots in the hash table (default: 521)*/
+    size_t rdcc_nbytes;  /* Size of chunk cache in bytes (default: 1 MiB)*/
+    double w0;           /* policy to flush chunks (default: 0.75)
+                          * 0: fully read/written chunks are treated no
+                          *    differently than other chunks
+                          * 1: fully read/written chunks are always preempted
+                          *    before other chunks
+                          */
+
+    err = H5Pget_cache(fapl_id, &mdc_nelmts, &rdcc_nslots, &rdcc_nbytes, &w0);
+    if (err < 0) HANDLE_ERROR("H5Pget_cache");
+
+    /* increase cache size to 64 MiB */
+    rdcc_nbytes = 67108864;
+
+    /* set to 1 suggested by HDF5 for when only reads or writes chunks once */
+    w0 = 1.;
+
+    /* rdcc_nslots should be a prime number and approximately 100 times number
+     * of chunks that can fit in rdcc_nbytes. The default value used by HDF5 is
+     * 521. Bigger prime numbers are 10007, 67231, etc.
+     */
+    rdcc_nslots = 67231;
+
+    err = H5Pset_cache(fapl_id, mdc_nelmts, rdcc_nslots, rdcc_nbytes, w0);
+    if (err < 0) HANDLE_ERROR("H5Pset_cache");
+ fn_exit:
+    return err_exit;
+}
+
+/*----< check_h5_objects() >-------------------------------------------------*/
+static
+int check_h5_objects(const char *filename, hid_t fid)
+{
+    ssize_t num_objs;
+    size_t ii, howmany;
+    H5I_type_t ot;
+    hid_t *objs;
+    char obj_name[1024];
+
+    num_objs = H5Fget_obj_count(fid, H5F_OBJ_ALL);
+    if (num_objs <= 0) return num_objs;
+    /* ignore FILE object */
+    if (num_objs > 1) printf("%zd object(s) open\n", num_objs);
+
+    objs = (hid_t*) malloc(num_objs * sizeof(hid_t));
+    howmany = H5Fget_obj_ids(fid, H5F_OBJ_ALL, num_objs, objs);
+    if (howmany > 1) printf("open objects:\n");
+
+    for (ii=0; ii<howmany; ii++) {
+	string type_name="";
+	ot = H5Iget_type(objs[ii]);
+	if (ot == H5I_FILE)      continue; /*  type_name = "H5I_FILE"; */
+	else if (ot == H5I_GROUP)     type_name = "H5I_GROUP";
+	else if (ot == H5I_DATATYPE)  type_name = "H5I_DATATYPE";
+	else if (ot == H5I_DATASPACE) type_name = "H5I_DATASPACE";
+	else if (ot == H5I_DATASET)   type_name = "H5I_DATASET";
+	else if (ot == H5I_ATTR)      type_name = "H5I_ATTR";
+	H5Iget_name(objs[ii], obj_name, 1024);
+	printf("%s %4zd: type %s, name %s\n",
+	       filename, ii, type_name.c_str(), obj_name);
+    }
+    free(objs);
+    return howmany;
+}
+
+/*----< allocate_buffer() >--------------------------------------------------*/
+/* support adding additional index values of integral type */
+int 
+allocate_buffer(void *&buffer, const size_t & len, const hid_t & h5type)
+{
+    htri_t equality = H5Tequal(h5type, H5T_INTEGER);
+    
+    if (equality > 0) { /* h5type is integral */
+	buffer = malloc(len * H5Tget_size(h5type));
+	return 0;
+    }
+    else if (equality == 0) { /* h5type is not integral */
+	printf("Unsupported datatype\n");
+	return -1;
+    }
+    else { /* equality check failed */
+	RETURN_ERROR("H5Tequal", "h5type");
+	/* returns -1 */
+    }
+    
+    /*
+    switch (H5Tget_class(h5type)) {
+    case H5T_NATIVE_CHAR:
+	buffer = (char*          ) malloc(len * sizeof(char          ));
+	break;			 				     
+    case H5T_NATIVE_SCHAR:	 				     
+	buffer = (signed char*   ) malloc(len * sizeof(signed char   ));
+	break;			 				     
+    case H5T_NATIVE_UCHAR:	 				     
+	buffer = (unsigned char* ) malloc(len * sizeof(unsigned char ));
+	break;			 				     
+    case H5T_NATIVE_SHORT:	 				     
+	buffer = (short*         ) malloc(len * sizeof(short         ));
+	break;
+    case H5T_NATIVE_USHORT:
+	buffer = (unsigned short*) malloc(len * sizeof(unsigned short));
+	break;
+    case H5T_NATIVE_INT:
+	buffer = (int*           ) malloc(len * sizeof(int           ));
+	break;
+    case H5T_NATIVE_UINT:
+        buffer = (unsigned int*  ) malloc(len * sizeof(unsigned int  ));
+	break;
+    case H5T_NATIVE_HSIZE:
+	buffer = (hsize_t*       ) malloc(len * sizeof(hsize_t       ));
+	break;
+    case H5T_NATIVE_HSSIZE:
+	buffer = (hssize_t*      ) malloc(len * sizeof(hssize_t      ));
+	break;
+    case H5T_NATIVE_HERR:
+	buffer = (herr_t*        ) malloc(len * sizeof(herr_t        ));
+	break;
+    default:
+	char dtype_name[1024];
+	herr_t err;
+	err = H5Tenum_nameof(h5type, dtype_name, 1024);
+	if(err < 0) RETURN_ERROR("H5Tenum_nameof", "h5type");
+	else {
+	    printf("Error: %s not supported\n", dtype_name);
+	    goto fn_exit;
+	}
+    }
+    */
+}
+
+
+
+/*----< usage() >------------------------------------------------------------*/
+static void
+usage(char *progname)
+{
+#define USAGE   "\
+  [-h]          print this command usage message\n\
+  [-v]          verbose mode (default: off)\n\
+  -s source     full path to dataset who's value will be injected into the /spill group\n\
+                multiple values allowed (required)\n\
+  file_name     input/output HDF5 file name (required)\n\n\
+  This utility program adds a new dataset in the /spill group of the input file.\n\
+  The new dataset should be single-valued, is determined by the source dataset,\n\
+  and is intended to be used as an additional index use for partition key generation.\n\
+  Requirements for the HDF5 file:\n\
+    1. must contain group /spill\n\
+    2. contains multiple groups at root level\n\
+    3. each group may contain multiple 2D datasets\n\
+    4. all datasets in the same group share the 1st dimension size\n\
+    5. each group must contain the source datasets\n\
+    6. the second dimension size of the source datasets must be 1\n\
+    7. data type of the source dataset(s) must be H5T_STD_U32LE\n\
+  *ph5concat version _PH5CONCAT_VERSION_ of _PH5CONCAT_RELEASE_DATE_\n"
+
+    printf("Usage: %s [-h|-v] -k base_name file_name\n%s\n", progname, USAGE);
+}
+
+
+int main(int argc, char **argv)
+{
+    char msg[1024], *infile=NULL, *grp_name;
+    hid_t file_id=-1, fapl_id=-1;
+    char * source=NULL;
+    int c, err_exit;
+    herr_t err;
+    hsize_t one[2]={1,1}, offs[2]={0,0}, lens[2]={1,1};
+    hid_t dset_id, mem_space_id, file_space_id;
+    int *inbuf, *outbuf;
+    bool dry_run;
+    hid_t spill_id, space_id, run_id, dcpl_id, newsrc_id;
+    hsize_t dset_dims[2], maxdims[2];
+    int ndims;
+    
+    verbose = 0; /* default is quiet */
+
+    /* command-line arguments */
+    while ((c = getopt(argc, argv, "hvns:")) != -1) {
+	switch(c) {
+	    case 'h': usage(argv[0]);
+		      err_exit = -1;
+		      goto fn_exit;
+	    case 'n': dry_run = true;
+		      break;
+	    case 's': source = strdup(optarg);
+		      break;
+	    case 'v': verbose = 1;
+	              break;
+	    default: break;
+	}
+    }
+    if (argv[optind] == NULL) { /* input file name is mandatory */
+        printf("input file name is missing\n");
+        usage(argv[0]);
+        err_exit = -1;
+        goto fn_exit;
+    }
+    if (source == NULL) { /* source dataset is required */
+	printf("source dataset is required\n");
+	usage(argv[0]);
+	err_exit = -1;
+	goto fn_exit;
+    }
+
+    infile = strdup(argv[optind]);
+
+    if (verbose) printf("input file: %s\n", infile);
+
+    /* create file access property for read and write */
+    fapl_id = H5Pcreate(H5P_FILE_ACCESS);
+    if (fapl_id < 0) HANDLE_ERROR("H5Pcreate");
+
+    /* increase cache size for raw data */
+    err = incr_raw_data_chunk_cache(fapl_id);
+    if (err < 0) HANDLE_ERROR("incr_raw_data_chunk_cache");
+    
+    if (dry_run)
+	/* read-only mode */
+	file_id = H5Fopen(infile, H5F_ACC_RDONLY, fapl_id);
+    else
+	/* read-and-write mode  */
+	file_id = H5Fopen(infile, H5F_ACC_RDWR, fapl_id);
+    if (file_id < 0) {
+        sprintf(msg, "Can't open input file %s\n", infile);
+        HANDLE_ERROR(msg);
+    }
+
+    /* create memspace */
+    mem_space_id = H5Screate_simple(2, lens, NULL);
+    if (mem_space_id < 0) HANDLE_ERROR("H5Screate_simple");
+    
+    /* open the source dataset */
+    dset_id = H5Dopen(file_id, source, H5P_DEFAULT);
+    if (dset_id < 0) RETURN_ERROR("H5Dopen", source);
+
+    /* allocate buffer for data to be read into */
+    inbuf = new int[1];
+
+    /* set the window */
+    file_space_id = H5Dget_space(dset_id);
+    if (file_space_id < 0) RETURN_ERROR("H5Dget_space", source);
+	        
+    err = H5Sselect_hyperslab(file_space_id, H5S_SELECT_SET, offs, NULL,
+			      one, lens);
+    if (err < 0) RETURN_ERROR("H5Sselect_hyperslab", source);
+
+    /* read data */
+    err = H5Dread(dset_id, H5T_NATIVE_INT, mem_space_id, file_space_id,
+		  H5P_DEFAULT, inbuf);
+    
+    if (err < 0) RETURN_ERROR("H5Dread", source);
+	
+    err = H5Dclose(dset_id);
+    if (err < 0) RETURN_ERROR("H5Dclose", source);
+    H5Sclose(file_space_id);
+
+    if(verbose) { /* print values we retrieved from the source datasets */
+	printf("%s = %d\n", source, *inbuf);
+    }
+    
+    /* open spill group */
+    spill_id = H5Gopen(file_id, "/spill", H5P_DEFAULT);
+    if (spill_id < 0) RETURN_ERROR("H5Gopen", "/spill");
+			
+    /* open run dataset in spill group to determine dataset size*/
+    run_id = H5Dopen(spill_id, "run", H5P_DEFAULT);
+    if (run_id < 0) RETURN_ERROR("H5Dopen", "run");
+
+    /* Get dimension sizes of run dataset */
+    space_id = H5Dget_space(run_id);
+    if (space_id < 0) RETURN_ERROR("H5Dget_space", "run");
+    ndims = H5Sget_simple_extent_dims(space_id, dset_dims, maxdims);
+    if (ndims != 2) RETURN_ERROR("H5Sget_simple_extent_dims", "run");
+
+    /* Get create property of run dataset when it was created */
+    dcpl_id = H5Dget_create_plist(run_id);
+    if (dcpl_id < 0) RETURN_ERROR("H5Dget_create_plist", "run");
+
+    /* close /spill/run */
+    err = H5Dclose(run_id);
+    if (err < 0) RETURN_ERROR("H5Dclose", "run");
+
+    if (verbose) printf("/spill/run dims (%d, 1)\n", dset_dims[0]);
+    
+    if (!dry_run) {
+	char * newsrc_name = basename(source);
+
+	/* allocate out buffer */
+	outbuf = (int*) malloc(dset_dims[0] * sizeof(int));
+	if (verbose) printf("Filling /spill/%s (%d, 1) with %d\n", newsrc_name, dset_dims[0], *inbuf);
+
+	/* fill out buffer with value determined from source */
+	for(auto ib = 0u; ib < dset_dims[0]; ib++) outbuf[ib] = inbuf[0];
+
+	/* create new dataset */
+	newsrc_id = H5Dcreate2(spill_id, newsrc_name, H5T_NATIVE_INT, space_id,
+			       H5P_DEFAULT, dcpl_id, H5P_DEFAULT);
+	if (newsrc_id < 0) RETURN_ERROR("H5Dcreate2", newsrc_name);
+	
+	/* write to new dataset */
+	if (dset_dims[0] > 0) {
+	    err = H5Dwrite(newsrc_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL,
+			   H5P_DEFAULT, outbuf);
+	    if (err < 0) RETURN_ERROR("H5Dwrite", newsrc_name);
+	}
+	
+	/* close dataset */
+	err = H5Dclose(newsrc_id);
+	if (err < 0) RETURN_ERROR("H5Dclose", newsrc_name);
+
+    }
+
+    
+    /* close spill group */
+    err = H5Gclose(spill_id);
+    if (err < 0) RETURN_ERROR("H5Gclose", "/spill");
+
+    /* release buffers */
+    if (outbuf != NULL) free(outbuf);
+    if (inbuf  != NULL) free(inbuf );
+ fn_exit:
+    if (file_id >= 0) {
+        check_h5_objects(infile, file_id);
+        err = H5Fclose(file_id);
+        if (err < 0) printf("Error at line %d: H5Fclose\n",__LINE__);
+    }
+    if (fapl_id >= 0) {
+        err = H5Pclose(fapl_id);
+        if (err < 0) printf("Error at line %d: H5Pclose\n",__LINE__);
+    }
+
+}
+

--- a/utils/sort_file_list.cpp
+++ b/utils/sort_file_list.cpp
@@ -59,43 +59,43 @@ typedef map<std::vector<unsigned int>, string, compv> tuple_map;
 
 /* parameters to be passed to the call back function */
 struct op_data {
-  std::vector<std::string> names;
-  std::vector<bool> is_set;
-  std::vector<unsigned int> event_index;
-  herr_t   err;
-  op_data(std::vector<std::string> _names) 
-    : names(_names) 
-  {    
-    is_set      = std::vector<bool        >(names.size(), false);
-    event_index = std::vector<unsigned int>(names.size(), 0    );
-  }
-  void add_level(std::string name)
-  {
-    names      .push_back(name);
-    is_set     .push_back(false);
-    event_index.push_back(0);
-  }
-  void reset()
-  {
-    for(auto iset = 0u; iset < is_set.size(); iset++)
-      is_set[iset] = false;
-  }
-  int index(std::string name) const
-  {
-    for(auto idx = 0; idx < names.size(); idx++) 
-      if(strcmp(name.c_str(), names[idx].c_str()) == 0) return idx;
-    return -1;
-  }
+    std::vector<std::string> names;
+    std::vector<bool> is_set;
+    std::vector<unsigned int> event_index;
+    herr_t   err;
+    op_data(std::vector<std::string> _names) 
+      : names(_names) 
+    {    
+      is_set      = std::vector<bool        >(names.size(), false);
+      event_index = std::vector<unsigned int>(names.size(), 0    );
+    }
+    void add_level(std::string name)
+    {
+      names      .push_back(name);
+      is_set     .push_back(false);
+      event_index.push_back(0);
+    }
+    void reset()
+    {
+      for(auto iset = 0u; iset < is_set.size(); iset++)
+        is_set[iset] = false;
+    }
+    int index(std::string name) const
+    {
+      for(auto idx = 0; idx < names.size(); idx++) 
+        if(strcmp(name.c_str(), names[idx].c_str()) == 0) return idx;
+      return -1;
+    }
 };
 
 /* string-based basename */
 std::string basename(std::string full_path)
 {
-  auto pos = full_path.find_last_of("/\\");
-  if(pos != string::npos)
-    return full_path.substr(pos+1);
-  else
-    return full_path;
+    auto pos = full_path.find_last_of("/\\");
+    if(pos != string::npos)
+      return full_path.substr(pos+1);
+    else
+      return full_path;
 }
 
 /*----< get_IDs() >----------------------------------------------------------*/
@@ -133,12 +133,12 @@ herr_t get_IDs(hid_t             loc_id,/* object ID */
      */
     int level_idx = -1;
     for(auto eidx = 0u; eidx < it_op->names.size(); eidx++) {      
-      if((std::string) dset_name == basename(it_op->names[eidx]))
-	level_idx = eidx;
-
+        if((std::string) dset_name == basename(it_op->names[eidx]))
+  	    level_idx = eidx;
+  
     }
     if(level_idx < 0) {
-      goto fn_exit;
+        goto fn_exit;
     }
 
     /* Open the dataset. Note that loc_id is not the dataset/group ID. */
@@ -172,18 +172,18 @@ herr_t get_IDs(hid_t             loc_id,/* object ID */
 
     /* get the first value of level */
     if(! it_op->is_set[level_idx]) {
-      it_op->is_set     [level_idx] = true;
-      it_op->event_index[level_idx] = buf[0];
+        it_op->is_set     [level_idx] = true;
+        it_op->event_index[level_idx] = buf[0];
     }
 
     /* check level in all groups for consistency */
     for(i=0; i<dset_dims[0]; i++) {
-      if(buf[i] != it_op->event_index[level_idx]) {
-	printf("Error: inconsistent %s ID %u, expecting %u\n",
-	       dset_name, it_op->event_index[level_idx]);
-	err_exit = -1;
-	goto fn_exit;
-      }
+        if(buf[i] != it_op->event_index[level_idx]) {
+	    printf("Error: inconsistent %s ID %u, expecting %u\n",
+		   dset_name, it_op->event_index[level_idx]);
+	    err_exit = -1;
+	    goto fn_exit;
+	}
     }
 
     delete [] buf;
@@ -219,7 +219,7 @@ usage(char *progname)
     6. data type of datasets 'run' and 'subrun' must be H5T_STD_U32LE\n\
   *ph5concat version _PH5CONCAT_VERSION_ of _PH5CONCAT_RELEASE_DATE_\n"
 
-    printf("Usage: %s [-h|-v|-d|-o outfile|-a /additiona/index...] infile\n%s\n", progname, USAGE);
+    printf("Usage: %s [-h|-v|-d|-o outfile|-a /additional/index ...] infile\n%s\n", progname, USAGE);
 }
 
 /*----< main() >-------------------------------------------------------------*/
@@ -323,11 +323,11 @@ int main(int argc, char **argv)
 
 
 	    if (verbose) {
-	      printf("File %zd:", i);
-	      for(auto eidx = 0u; eidx < it_op.names.size(); eidx++) {
-		printf(" %s ID = %d", it_op.names[eidx].c_str(), it_op.event_index[eidx]);
-	      }
-	      printf("\n");
+	        printf("File %zd:", i);
+		for(auto eidx = 0u; eidx < it_op.names.size(); eidx++) {
+		  printf(" %s ID = %d", it_op.names[eidx].c_str(), it_op.event_index[eidx]);
+		}
+		printf("\n");
 	    }
 
             /* use sorted map in an increasing order of run and subrun */
@@ -343,36 +343,36 @@ int main(int argc, char **argv)
             if (mem_space_id < 0) HANDLE_ERROR("H5Screate_simple");
 
 	    for(auto eidx = 0u; eidx < it_op.names.size(); eidx++) {
-	      /* open the dataset */
-	      dset_id = H5Dopen(file_id, it_op.names[eidx].c_str(), H5P_DEFAULT);
-	      if (dset_id < 0) HANDLE_ERROR("H5Dopen");
-	      
-	      
-	      file_space_id = H5Dget_space(dset_id);
-	      if (file_space_id < 0) HANDLE_ERROR("H5Dget_space");
-
-	      /* set the window */
-	      err = H5Sselect_hyperslab(file_space_id, H5S_SELECT_SET, offs, NULL,
-					one, lens);
-	      if (err < 0) HANDLE_ERROR("H5Sselect_hyperslab");
-
-	      /* read data */
-	      err = H5Dread(dset_id, H5T_NATIVE_UINT, mem_space_id, file_space_id,
-			    H5P_DEFAULT, &it_op.event_index[eidx]);
-	      if (err < 0) HANDLE_ERROR("H5Dread");
-
-	      err = H5Dclose(dset_id);
-	      if (err < 0) HANDLE_ERROR("H5Dclose");
-	      H5Sclose(file_space_id);
+	        /* open the dataset */
+	        dset_id = H5Dopen(file_id, it_op.names[eidx].c_str(), H5P_DEFAULT);
+	        if (dset_id < 0) HANDLE_ERROR("H5Dopen");
+	        
+	        
+	        file_space_id = H5Dget_space(dset_id);
+	        if (file_space_id < 0) HANDLE_ERROR("H5Dget_space");
+	        
+	        /* set the window */
+	        err = H5Sselect_hyperslab(file_space_id, H5S_SELECT_SET, offs, NULL,
+	        				one, lens);
+	        if (err < 0) HANDLE_ERROR("H5Sselect_hyperslab");
+	        
+	        /* read data */
+	        err = H5Dread(dset_id, H5T_NATIVE_UINT, mem_space_id, file_space_id,
+	        		    H5P_DEFAULT, &it_op.event_index[eidx]);
+	        if (err < 0) HANDLE_ERROR("H5Dread");
+	        
+	        err = H5Dclose(dset_id);
+	        if (err < 0) HANDLE_ERROR("H5Dclose");
+	        H5Sclose(file_space_id);
 	    }
             H5Sclose(mem_space_id);
 
             if (verbose) {
-	      printf("File %zd:", i);
-	      for(auto eidx = 0u; eidx < it_op.names.size(); eidx++) {
-		printf(" %s ID = %d", it_op.names[eidx].c_str(), it_op.event_index[eidx]);
-	      }
-	      printf("\n");
+	        printf("File %zd:", i);
+	        for(auto eidx = 0u; eidx < it_op.names.size(); eidx++) {
+		    printf(" %s ID = %d", it_op.names[eidx].c_str(), it_op.event_index[eidx]);
+	        }
+	        printf("\n");
 	    }
 
             /* use sorted map in an increasing order of run and subrun */

--- a/utils/sort_file_list.cpp
+++ b/utils/sort_file_list.cpp
@@ -43,16 +43,16 @@ static int verbose, debug;
 const std::vector<std::string> DEFAULT_LEVELS {"/spill/run", "/spill/subrun"};
 
 struct compv {
-  bool operator()(const std::vector<unsigned int>& lhs, const std::vector<unsigned int>& rhs)
-  {
-    assert(lhs.size() == rhs.size());
+    bool operator()(const std::vector<unsigned int>& lhs, const std::vector<unsigned int>& rhs)
+    {
+	assert(lhs.size() == rhs.size());
   
-    for(auto i = 0u; i < lhs.size(); i++) {
-      if(lhs[i] < rhs[i]) return true;
-      if(lhs[i] > rhs[i]) return false;
+	for(auto i = 0u; i < lhs.size(); i++) {
+	    if(lhs[i] < rhs[i]) return true;
+	    if(lhs[i] > rhs[i]) return false;
+	}
+	return false;
     }
-    return false;
-  }
 };
 
 typedef map<std::vector<unsigned int>, string, compv> tuple_map;
@@ -347,18 +347,17 @@ int main(int argc, char **argv)
 	        dset_id = H5Dopen(file_id, it_op.names[eidx].c_str(), H5P_DEFAULT);
 	        if (dset_id < 0) HANDLE_ERROR("H5Dopen");
 	        
-	        
 	        file_space_id = H5Dget_space(dset_id);
 	        if (file_space_id < 0) HANDLE_ERROR("H5Dget_space");
 	        
 	        /* set the window */
 	        err = H5Sselect_hyperslab(file_space_id, H5S_SELECT_SET, offs, NULL,
-	        				one, lens);
+					  one, lens);
 	        if (err < 0) HANDLE_ERROR("H5Sselect_hyperslab");
 	        
 	        /* read data */
 	        err = H5Dread(dset_id, H5T_NATIVE_UINT, mem_space_id, file_space_id,
-	        		    H5P_DEFAULT, &it_op.event_index[eidx]);
+			      H5P_DEFAULT, &it_op.event_index[eidx]);
 	        if (err < 0) HANDLE_ERROR("H5Dread");
 	        
 	        err = H5Dclose(dset_id);

--- a/utils/sort_file_list.cpp
+++ b/utils/sort_file_list.cpp
@@ -40,7 +40,7 @@ static int verbose, debug;
     goto fn_exit; \
 }
 
-const std::vector<std::string> DEFAULT_LEVELS {"/spill/run", "/spill/subrun", "/rec.hdr/cycle"};
+const std::vector<std::string> DEFAULT_LEVELS {"/spill/run", "/spill/subrun"};
 
 struct compv {
   bool operator()(const std::vector<unsigned int>& lhs, const std::vector<unsigned int>& rhs)
@@ -203,11 +203,14 @@ usage(char *progname)
   [-h]          print this command usage message\n\
   [-v]          verbose mode (default: off)\n\
   [-d]          debug mode (default: off)\n\
+  [-a]          full path to dataset used as additional index in multi-index sorting\n\
+                multiple values allowed\n\
   [-o outfile]  output file name (default: 'out_list.txt')\n\
   infile        input file name contains a list of HDF5 file names (required)\n\n\
   This utility program re-order the files in infile into a sorted list based\n\
-  on the increasing order of 'run' and 'subrun' IDs. Requirements for the\n\
-  input HDF5 files:\n\
+  on the increasing order of 'run' and 'subrun' IDs. Additional IDs can be used to sort with\n\
+  argument -a. Eg, -a /rec.hdr/cycle.\n\
+  Requirements for the input HDF5 files:\n\
     1. must contain datasets '/spill/run' and '/spill/subrun'\n\
     2. may contain multiple groups at root level\n\
     3. each group may contain multiple 2D datasets\n\
@@ -216,7 +219,7 @@ usage(char *progname)
     6. data type of datasets 'run' and 'subrun' must be H5T_STD_U32LE\n\
   *ph5concat version _PH5CONCAT_VERSION_ of _PH5CONCAT_RELEASE_DATE_\n"
 
-    printf("Usage: %s [-h|-v|-d|-o outfile] infile\n%s\n", progname, USAGE);
+    printf("Usage: %s [-h|-v|-d|-o outfile|-a /additiona/index...] infile\n%s\n", progname, USAGE);
 }
 
 /*----< main() >-------------------------------------------------------------*/
@@ -239,8 +242,10 @@ int main(int argc, char **argv)
     debug   = 0; /* default is no */
 
     /* command-line arguments */
-    while ((c = getopt(argc, argv, "hvdo:")) != -1)
+    while ((c = getopt(argc, argv, "hvda:o:")) != -1)
         switch(c) {
+	    case 'a': it_op.add_level(optarg);
+	              break;
             case 'h': usage(argv[0]);
                       err_exit = -1;
                       goto fn_exit;

--- a/utils/sort_file_list.cpp
+++ b/utils/sort_file_list.cpp
@@ -188,7 +188,7 @@ herr_t get_IDs(hid_t             loc_id,/* object ID */
 
     delete [] buf;
 
- fn_exit:
+fn_exit:
     free(path);
 
     it_op->err = err_exit;
@@ -315,7 +315,7 @@ int main(int argc, char **argv)
 			    &it_op, H5O_INFO_ALL);
             if (err < 0) HANDLE_ERROR("H5Ovisit3");
 #else
-	    err = H5Ovisit(file_id, H5_INDEX_NAME, H5_ITER_NATIVE, get_IDs,
+            err = H5Ovisit(file_id, H5_INDEX_NAME, H5_ITER_NATIVE, get_IDs,
 			   &it_op);
             if (err < 0) HANDLE_ERROR("H5Ovisit");
 #endif
@@ -338,7 +338,7 @@ int main(int argc, char **argv)
             unsigned int run, subrun;
             hsize_t one[2]={1,1}, offs[2]={0,0}, lens[2]={1,1};
             hid_t dset_id, mem_space_id, file_space_id;
-	    
+
             mem_space_id = H5Screate_simple(2, lens, NULL);
             if (mem_space_id < 0) HANDLE_ERROR("H5Screate_simple");
 


### PR DESCRIPTION
Hello, 

I've recently set out to test your software on the concatenation of NOvA MC files and found that the "cycle" index that is only relevant in NOvA MC is not properly accounted for. The cycle value is a way of indexing MC files that are generated to describe the same run/subrun. 
This will cause a few issues. 
1. Where I noticed the issue is with the sort_file_list program. This program will drop files from the sorting map when another file of the same run/subrun combination is inserted. This pull request addresses the issue by generalizing the sorting process and supports the option for additional values to be considered in the sorting.
2. Not addressed by this pull request is the issue of the partition key, which assumes run and subrun will be sufficient to uniquely index all events in a concatenated file. This assumption won't hold when two MC files from the same run and subrun, but different cycle, are concatenated together.
3. Other issues that may arise where the assumption that run and subrun uniquely index events is not met.

I've recently met with Marc Paterno and Saba Sehrish to discuss these issues and we have some ideas to address them that I will be working on in the coming weeks. I was also invited to next Tuesday's meeting with Marc, Saba, and you all where we can have more discussion. 

If you have any additional feedback, questions, or concerns, please let me know. Looking forward to discussing this more.

Derek