### PR TITLE
Remove use of H5get_alloc_stats

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -51,6 +51,8 @@ Bug fix:
   + Fix compression threshold calculation. See a9ea841
 
 Other changes
+  + Remove the HDF5 metadata memory footprint profiling, as H5get_alloc_stats
+    has been removed from HDF5 since 1.14.0. See PR #5.
   + Remove the requirement of group `/spill`. See d4e0852
   + Change chunk setting for small datasets. Set the chunk size to 256K
     element, no matter if the dataset dim[0] is smaller than 256K element or

--- a/configure.ac
+++ b/configure.ac
@@ -354,9 +354,6 @@ AC_CHECK_DECL(H5Ovisit3,
 AC_CHECK_DECL(H5Treclaim,
               [AC_DEFINE(HAS_H5TRECLAIM, 1, [Define if API H5Treclaim is defined])],
               [], [[#include <hdf5.h>]])
-AC_CHECK_DECL(H5get_alloc_stats,
-              [AC_DEFINE(HAS_H5GET_ALLOC_STATS, 1, [Define if API H5get_alloc_stats is defined])],
-              [], [[#include <hdf5.h>]])
 
 AC_ARG_VAR(TESTMPIRUN, [MPI run command for "make check", @<:@default: mpiexec@:>@])
 if test "x${TESTMPIRUN}" = x ; then


### PR DESCRIPTION
HDF5 has removed the API H5get_alloc_stats.
https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.14/hdf5-1.14.0/src/hdf5-1.14.0-RELEASE.txt