### PR TITLE
fix compilation errors on mac os

### DIFF
--- a/utils/add_key.cpp
+++ b/utils/add_key.cpp
@@ -21,7 +21,7 @@
 #include <unordered_map>
 #include <vector>
 #include <tuple>
-#include <bits/stdc++.h>
+#include <map>
 using namespace std;
 
 #include <hdf5.h>

--- a/utils/add_spill_index.cpp
+++ b/utils/add_spill_index.cpp
@@ -291,7 +291,7 @@ int main(int argc, char **argv)
     /* /spill/run should not be of zero-sized */
     if (dset_dims[0] == 0) RETURN_ERROR("Zero-sized group '/spill'", "run");
 
-    newsrc_name = basename(src_path);
+    newsrc_name = &basename(src_path)[0];
     src_exist = H5Lexists(spill_id, newsrc_name, H5P_DEFAULT);
     if (src_exist < 0) RETURN_ERROR("H5Lexists", newsrc_name)
     if (src_exist > 0) {


### PR DESCRIPTION
These changes fix compilation errors on my mac os laptop.
A better solution may be found for fixing the add_spill_index.cpp error.